### PR TITLE
Follow laravel in the way that attributes are first then relation

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: jenssegers
-tidelift: "packagist/jenssegers/mongodb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,29 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+None yet.
+
+## [10.0] - 2023-08-22
+
+### Added
+- MongoDB v6.0 supports and tests
+- use Mongosh in tests instead of the old Mongo
+- Mysql 8 Hybrid relation tests
+
+### Removed
+- MongoDB v4.* support was dropped
+
+### Fixed
+- Fixing the priority between attributes and relations dynamic property call to be the same as Laravel, that mean attribute first then relation (previous it was relation then attribute)
+- using function names that exist as attribute accessor/caster: previously if you use a function name that has an accessor; say u use foo() and you have getFooAttribute, calling $model->foo will always fail as the function is called before the accessor, this has been fixed.
+
+### Breaking
+- EmbedsOne and EmbedsMany now require return type to work (Example in the documentation has been updated)
+- You can't have the belongsToMany foreign key to be the same as the relation name (check documentation for more details)
 
 ## [3.9.2] - 2022-09-01
 
-### Addded 
+### Addded
 - Add single word name mutators [#2438](https://github.com/jenssegers/laravel-mongodb/pull/2438) by [@RosemaryOrchard](https://github.com/RosemaryOrchard) & [@mrneatly](https://github.com/mrneatly).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -839,6 +839,7 @@ class User extends Model
     }
 }
 ```
+**Warning:** naming the foreign key same as the relation name will prevent the relation for being called on dynamic property, i.e. in the example above if you replaced `group_ids` with `groups` calling `$user->groups` will return the column instead of the relation.
 
 ### EmbedsMany Relationship
 
@@ -846,12 +847,15 @@ If you want to embed models, rather than referencing them, you can use the `embe
 
 **REMEMBER**: These relations return Eloquent collections, they don't return query builder objects!
 
+**Breaking changes** starting from v10.0 you need to define the return type of EmbedsOne and EmbedsMany relation for it to work
+
 ```php
 use Jenssegers\Mongodb\Eloquent\Model;
+use Jenssegers\Mongodb\Relations\EmbedsMany;
 
 class User extends Model
 {
-    public function books()
+    public function books(): EmbedsMany
     {
         return $this->embedsMany(Book::class);
     }
@@ -920,10 +924,11 @@ Like other relations, embedsMany assumes the local key of the relationship based
 
 ```php
 use Jenssegers\Mongodb\Eloquent\Model;
+use Jenssegers\Mongodb\Relations\EmbedsMany;
 
 class User extends Model
 {
-    public function books()
+    public function books(): EmbedsMany
     {
         return $this->embedsMany(Book::class, 'local_key');
     }
@@ -936,12 +941,15 @@ Embedded relations will return a Collection of embedded items instead of a query
 
 The embedsOne relation is similar to the embedsMany relation, but only embeds a single model.
 
+**Breaking changes** starting from v10.0 you need to define the return type of EmbedsOne and EmbedsMany relation for it to work
+
 ```php
 use Jenssegers\Mongodb\Eloquent\Model;
+use Jenssegers\Mongodb\Relations\EmbedsOne;
 
 class Book extends Model
 {
-    public function author()
+    public function author(): EmbedsOne
     {
         return $this->embedsOne(Author::class);
     }

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -2,11 +2,6 @@
 
 namespace Jenssegers\Mongodb\Eloquent;
 
-use Jenssegers\Mongodb\Relations\EmbedsMany;
-use Jenssegers\Mongodb\Relations\EmbedsOne;
-use ReflectionException;
-use ReflectionMethod;
-use ReflectionNamedType;
 use function array_key_exists;
 use DateTimeInterface;
 use function explode;
@@ -20,9 +15,14 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use function in_array;
 use Jenssegers\Mongodb\Query\Builder as QueryBuilder;
+use Jenssegers\Mongodb\Relations\EmbedsMany;
+use Jenssegers\Mongodb\Relations\EmbedsOne;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
+use ReflectionException;
+use ReflectionMethod;
+use ReflectionNamedType;
 use function uniqid;
 
 abstract class Model extends BaseModel

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -148,28 +148,28 @@ abstract class Model extends BaseModel
     /**
      * @inheritdoc
      */
-    public function getAttribute($key)
-    {
-        if (! $key) {
-            return;
-        }
-
-        // Dot notation support.
-        if (Str::contains($key, '.') && Arr::has($this->attributes, $key)) {
-            return $this->getAttributeValue($key);
-        }
-
-        // This checks for embedded relation support.
-        if (
-            method_exists($this, $key)
-            && ! method_exists(self::class, $key)
-            && ! $this->hasAttributeGetMutator($key)
-        ) {
-            return $this->getRelationValue($key);
-        }
-
-        return parent::getAttribute($key);
-    }
+//    public function getAttribute($key)
+//    {
+//        if (! $key) {
+//            return;
+//        }
+//
+//        // Dot notation support.
+//        if (Str::contains($key, '.') && Arr::has($this->attributes, $key)) {
+//            return $this->getAttributeValue($key);
+//        }
+//
+//        // This checks for embedded relation support.
+//        if (
+//            method_exists($this, $key)
+//            && ! method_exists(self::class, $key)
+//            && ! $this->hasAttributeGetMutator($key)
+//        ) {
+//            return $this->getRelationValue($key);
+//        }
+//
+//        return parent::getAttribute($key);
+//    }
 
     /**
      * @inheritdoc

--- a/tests/HybridRelationsTest.php
+++ b/tests/HybridRelationsTest.php
@@ -13,6 +13,7 @@ class HybridRelationsTest extends TestCase
         MysqlUser::executeSchema();
         MysqlBook::executeSchema();
         MysqlRole::executeSchema();
+//        MysqlGroup::executeSchema();
     }
 
     public function tearDown(): void
@@ -20,7 +21,18 @@ class HybridRelationsTest extends TestCase
         MysqlUser::truncate();
         MysqlBook::truncate();
         MysqlRole::truncate();
+//        MysqlGroup::truncate();
     }
+
+//    public function testMysqlGroups()
+//    {
+//        $user = new MysqlUser;
+//        $user->name = 'John Doe';
+//        $user->save();
+//        $this->assertIsInt($user->id);
+//
+//        $group = $user->groups()->create(['name' => 'test']);
+//    }
 
     public function testMysqlRelations()
     {

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -801,4 +801,11 @@ class ModelTest extends TestCase
         $this->assertSame(MemberStatus::Member->value, $check->getRawOriginal('member_status'));
         $this->assertSame(MemberStatus::Member, $check->member_status);
     }
+
+    public function testGetFooAttributeAccessor()
+    {
+        $user = new User();
+
+        $this->assertSame('normal attribute', $user->foo);
+    }
 }

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -334,8 +334,8 @@ class RelationsTest extends TestCase
         $group = Group::find($group->_id);
 
         // Check for custom relation attributes
-        $this->assertArrayHasKey('users', $group->getAttributes());
-        $this->assertArrayHasKey('groups', $user->getAttributes());
+        $this->assertArrayHasKey('user_ids', $group->getAttributes());
+        $this->assertArrayHasKey('group_ids', $user->getAttributes());
 
         // Assert they are attached
         $this->assertContains($group->_id, $user->groups->pluck('_id')->toArray());

--- a/tests/models/Group.php
+++ b/tests/models/Group.php
@@ -13,6 +13,6 @@ class Group extends Eloquent
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany('User', 'users', 'groups', 'users', '_id', '_id', 'users');
+        return $this->belongsToMany('User');
     }
 }

--- a/tests/models/MysqlGroup.php
+++ b/tests/models/MysqlGroup.php
@@ -30,7 +30,7 @@ class MysqlGroup extends Eloquent
         /** @var MySqlBuilder $schema */
         $schema = Schema::connection('mysql');
 
-        if (!$schema->hasTable('groups')) {
+        if (! $schema->hasTable('groups')) {
             Schema::connection('mysql')->create('groups', function (Blueprint $table) {
                 $table->id();
                 $table->string('name');
@@ -38,7 +38,7 @@ class MysqlGroup extends Eloquent
             });
         }
 
-        if (!$schema->hasTable('group_user')) {
+        if (! $schema->hasTable('group_user')) {
             Schema::connection('mysql')->create('group_user', function (Blueprint $table) {
                 $table->foreignId('user_id')->constrained('users')->cascadeOnUpdate()->cascadeOnDelete();
                 $table->foreignId('group_id')->constrained('groups')->cascadeOnUpdate()->cascadeOnDelete();

--- a/tests/models/MysqlGroup.php
+++ b/tests/models/MysqlGroup.php
@@ -3,39 +3,23 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\MySqlBuilder;
 use Illuminate\Support\Facades\Schema;
 use Jenssegers\Mongodb\Eloquent\HybridRelations;
 
-class MysqlUser extends Eloquent
+class MysqlGroup extends Eloquent
 {
     use HybridRelations;
 
     protected $connection = 'mysql';
-    protected $table = 'users';
+    protected $table = 'groups';
     protected static $unguarded = true;
+    protected $primaryKey = 'name';
 
-    public function books(): HasMany
+    public function users(): BelongsToMany
     {
-        return $this->hasMany('Book', 'author_id');
-    }
-
-    public function role(): HasOne
-    {
-        return $this->hasOne('Role');
-    }
-
-    public function mysqlBooks(): HasMany
-    {
-        return $this->hasMany(MysqlBook::class);
-    }
-
-    public function groups(): BelongsToMany
-    {
-        return $this->belongsToMany(MysqlGroup::class, 'group_user', 'user_id', 'group_id');
+        return $this->belongsToMany(MysqlUser::class);
     }
 
     /**
@@ -46,11 +30,18 @@ class MysqlUser extends Eloquent
         /** @var MySqlBuilder $schema */
         $schema = Schema::connection('mysql');
 
-        if (! $schema->hasTable('users')) {
-            Schema::connection('mysql')->create('users', function (Blueprint $table) {
+        if (!$schema->hasTable('groups')) {
+            Schema::connection('mysql')->create('groups', function (Blueprint $table) {
                 $table->id();
                 $table->string('name');
                 $table->timestamps();
+            });
+        }
+
+        if (!$schema->hasTable('group_user')) {
+            Schema::connection('mysql')->create('group_user', function (Blueprint $table) {
+                $table->foreignId('user_id')->constrained('users')->cascadeOnUpdate()->cascadeOnDelete();
+                $table->foreignId('group_id')->constrained('groups')->cascadeOnUpdate()->cascadeOnDelete();
             });
         }
     }

--- a/tests/models/User.php
+++ b/tests/models/User.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Carbon\Carbon;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
@@ -11,6 +12,8 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Eloquent\HybridRelations;
 use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+use Jenssegers\Mongodb\Relations\EmbedsMany;
+use Jenssegers\Mongodb\Relations\EmbedsOne;
 
 /**
  * Class User.
@@ -20,9 +23,9 @@ use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
  * @property string $email
  * @property string $title
  * @property int $age
- * @property \Carbon\Carbon $birthday
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
+ * @property Carbon $birthday
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property string $username
  * @property MemberStatus member_status
  */
@@ -73,7 +76,7 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
 
     public function groups()
     {
-        return $this->belongsToMany('Group', 'groups', 'users', 'groups', '_id', '_id', 'groups');
+        return $this->belongsToMany('Group');
     }
 
     public function photos()
@@ -81,12 +84,12 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
         return $this->morphMany('Photo', 'has_image');
     }
 
-    public function addresses()
+    public function addresses(): EmbedsMany
     {
         return $this->embedsMany('Address');
     }
 
-    public function father()
+    public function father(): EmbedsOne
     {
         return $this->embedsOne('User');
     }
@@ -102,5 +105,15 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
             get: fn ($value) => $value,
             set: fn ($value) => Str::slug($value)
         );
+    }
+
+    public function getFooAttribute()
+    {
+        return 'normal attribute';
+    }
+
+    public function foo()
+    {
+        return 'normal function';
     }
 }


### PR DESCRIPTION
Follow laravel in the way that attributes are first then relation, that is to prevent overriding of casts, accessors, etc ...
we should use the correct order from Laravel.